### PR TITLE
Use native path methods for filepath manipulation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "5"
+  - "4.4"
   - "0.12"
 sudo: false

--- a/index.js
+++ b/index.js
@@ -116,9 +116,10 @@ function sassGenerateContents(destFilePath, creds, options){
 		return path.split('/').join(':').split('\\').join(':');
 	}
 
-	function getSection(path){
+	function getSection(filePath){
+		var fileDirArray = path.parse(filePath).dir.split(path.sep);
 
-		return replacePath(path).split(':').reverse()[1];
+		return fileDirArray[fileDirArray.length - 1];
 	}
 
 	function getFileName(filePath) {

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function sassGenerateContents(destFilePath, creds, options){
 		for(var i = 0; i < len; i++){
 			spaceArr.push(spacer);
 		}
+
 		return spaceArr.join('');
 	}
 
@@ -133,10 +134,6 @@ function sassGenerateContents(destFilePath, creds, options){
 		});
 
 		return newFile;
-	}
-
-	function getBase(filePath){
-		return filePath.substring(0, replacePath(filePath).lastIndexOf(':'));
 	}
 
 	function throwWarning(fileName){

--- a/index.js
+++ b/index.js
@@ -40,11 +40,11 @@ function sassGenerateContents(destFilePath, creds, options){
 		var longest = 0;
 		for (var prop in propList){
 			if (propList.hasOwnProperty(prop)) {
-		    	var propLength = prop.length
-		    	if(propLength > longest) {
-		    		longest = propLength;
-		    	}
-		    }
+				var propLength = prop.length
+				if(propLength > longest) {
+					longest = propLength;
+				}
+			}
 		}
 		return longest;
 	}
@@ -60,13 +60,13 @@ function sassGenerateContents(destFilePath, creds, options){
 		for (var cred in credsObj){
 			if (credsObj.hasOwnProperty(cred)) {
 
-		       var val = credsObj[cred];
-		       var credLength = cred.length;
-		       var diff = credLongest - credLength;
-		       var spacer = getSpacer(diff, ' ');
-		       credStr.push('  ' + cred + ': ' + spacer + '' + val);
+				var val = credsObj[cred];
+				var credLength = cred.length;
+				var diff = credLongest - credLength;
+				var spacer = getSpacer(diff, ' ');
+				credStr.push('  ' + cred + ': ' + spacer + '' + val);
 
-		    }
+			}
 		}
 		credStr.push('\n/* ============================================================ *\\\n\n');
 
@@ -166,7 +166,7 @@ function sassGenerateContents(destFilePath, creds, options){
 		if (file.isStream()) {
 			cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
 			return;
-    }
+		}
 
 		var content = file.contents.toString('utf8');
 
@@ -176,6 +176,7 @@ function sassGenerateContents(destFilePath, creds, options){
 			throwWarning(fileName);
 			return cb();
 		}
+
 		if(String(firstChars) !== '//' && !opts.forceComments){
 			comments = '* ';
 		}

--- a/index.js
+++ b/index.js
@@ -111,11 +111,6 @@ function sassGenerateContents(destFilePath, creds, options){
 		return;
 	}
 
-	function replacePath(path){
-		//hack for windows and mac filepath
-		return path.split('/').join(':').split('\\').join(':');
-	}
-
 	function getSection(filePath){
 		var fileDirArray = path.parse(filePath).dir.split(path.sep);
 

--- a/index.js
+++ b/index.js
@@ -121,8 +121,8 @@ function sassGenerateContents(destFilePath, creds, options){
 		return replacePath(path).split(':').reverse()[1];
 	}
 
-	function getFileName(filePath){
-		return filePath.substring(filePath.length, replacePath(filePath).lastIndexOf(':')+1);
+	function getFileName(filePath) {
+		return path.basename(filePath);
 	}
 
 	function createFile(destFilePath){


### PR DESCRIPTION
Under certain circumstances the paths for includes can be constructed without path separators on Windows.

Moving to using the native path methods rather than trying to directly manipulate the paths resolves this.