### PR TITLE
fix: Use / for import paths to avoid escape char errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,8 +96,6 @@ function sassGenerateContents(destFilePath, creds, options){
 			commentsArr.push(comments);
 		}
 
-
-
 		// build site credentials iff passed in
 		var credsArr = createCreds(creds);
 
@@ -134,6 +132,12 @@ function sassGenerateContents(destFilePath, creds, options){
 
 	function throwWarning(fileName){
 		gutil.log(PLUGIN_NAME + ' Comments missing or malformed in file: ' + fileName + ' - File not included\n');
+	}
+
+	function generateImportString(filePath) {
+		var pathArray = path.normalize(filePath).split(path.sep);
+
+		return '@import "' + pathArray.join('/') + '";';
 	}
 
 
@@ -176,7 +180,7 @@ function sassGenerateContents(destFilePath, creds, options){
 
 		comments = comments.replace('//', '* ');
 
-		imports = '@import "' + currentFilePath + '";';
+		imports = generateImportString(currentFilePath);
 
 		updateFile(newFile, imports, comments);
 


### PR DESCRIPTION
Using the native \ as a path separator on windows can occasionally run into issues when it precedes an escape character in the path.

Updating to use / within the path avoids this issue. Sass automatically converts the path while compiling so either version is valid on any platform.