### PR TITLE
Resolve an issue where the output file was constructed multiple times per run

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,18 @@ var File = gutil.File;
 // Consts
 const PLUGIN_NAME = 'sass-generate-contents';
 
+function shouldIncludeImport(existingImports, newImport) {
+	return existingImports.indexOf(newImport) < 0;
+}
+
+function addSectionIfNeeded(currentSection, comments) {
+	var section = getSection(currentFilePath);
+	if (section !== currentSection) {
+		currentSection = section;
+		commentsArr.push('* \n* ' + currentSection.toUpperCase());
+	}
+}
+
 function sassGenerateContents(destFilePath, creds, options){
 
 	var defaults = {
@@ -79,7 +91,7 @@ function sassGenerateContents(destFilePath, creds, options){
 	}
 
 	function addSection(currentFilePath) {
-		let section = getSection(currentFilePath);
+		var section = getSection(currentFilePath);
 		if (section !== currentSection) {
 			currentSection = section;
 			commentsArr.push('* \n* ' + currentSection.toUpperCase());


### PR DESCRIPTION
The output file had a buffer instantiated and a full content generated for each potential import file found. E.g. If 18 import files were found the full contents of the output file would be generated 18 times, with memory allocation to match.

This had two consequences:

1. The function runs slower than it needed to because of the extra work, an issue that is exacerbated the larger the number of imports.
2. Any following functions piped after sass-generate-contents would be run multiple times rather than once, slowing down the rest of the chain.

I resolved the issue by moving the file construction code in to a function run on stream end rather than on each iteration.