### PR TITLE
Simplify the test structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "license": "ISC",
   "devDependencies": {
     "mocha": "^2.2.5",
+    "read-vinyl-file-stream": "^2.0.3",
     "should": "^6.0.3",
     "stream-assert": "^2.0.2"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -72,7 +72,7 @@ describe('gulp-sass-generate-contents', function() {
             settings: { forceComments: false },
             assertion: function (fileContent) {
                 fileContent.should.containWithin('no-comments-file.scss');
-                }
+            }
         })
             .pipe(assert.end(done));
     });
@@ -90,7 +90,7 @@ describe('gulp-sass-generate-contents', function() {
             }
         })
             .pipe(assert.end(done));
-            });
+    });
 
     it('should not output table of contents comment block', function (done) {
         gulpTestRunner({
@@ -105,53 +105,6 @@ describe('gulp-sass-generate-contents', function() {
             }
         })
             .pipe(assert.end(done));
-    });
-
-                if (err) {
-                    return console.log(err);
-                }
-
-                if(data.indexOf(testText) > 0){
-                    hasTestText = 1;
-                }
-
-                hasTestText.should.be.exactly(1);
-                done();
-                
-            });
-        });
-    });
-
-    it('should not output table of contents comment block', function (done) {
-
-        var testText = '* CONTENTS';
-        var testFiles = [
-            config.src + '/' + config.dirs.styles + '/components/_test.scss',
-            config.src + '/' + config.dirs.styles + '/components/_test2.scss'
-        ];
-        var generatedFile = config.src + '/' + config.dirs.styles + '/_no-contents-table.scss';
-
-        gulp.src(testFiles)
-        .pipe(gsgc(generatedFile, creds, { contentsTable: false }))
-        .pipe(gulp.dest(config.src + '/' + config.dirs.styles))
-        .on('end', function(callback){
-            var hasTestText = 0,
-                fs = require('fs');
-            fs.readFile(generatedFile, 'utf8', function (err,data) {
-
-                if (err) {
-                    return console.log(err);
-                }
-
-                if(data.indexOf(testText) < 0){
-                    hasTestText = 1;
-                }
-
-                hasTestText.should.be.exactly(1);
-                done();
-                
-            });
-        });
     });
 
 });


### PR DESCRIPTION
There was a bit of duplicated code and synchronous file reading for the tests to run.
I've added a custom 'should' assertion, started using the raw file stream rather than reading from disk, and refactored the duplicated code to reduce the test cases to things specific to the test.

This could be improved a bit more with arrow functions for the assertions but that isn't supported on a lot of the target platforms