### PR TITLE
Optimise the travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: node_js
 node_js:
+  - "9"
+  - "8"
+  - "6"
   - "5"
-  - "4.4"
+  - "4"
   - "0.12"
 sudo: false
+cache:
+  directories:
+    — node_modules
+git:
+  depth: 1


### PR DESCRIPTION
    Update the travis file to include more modern versions of Node, only check out the last commit on
    build, and start caching the node_modules dir to speed up builds