### PR TITLE
Add option to exclude file extensions from the generated file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # gulp-sass-generate-contents <a href="https://travis-ci.org/andrewbrandwood/gulp-sass-generate-contents"><img align="right" src="https://travis-ci.org/andrewbrandwood/gulp-sass-generate-contents.svg?branch=master" alt="Build status" /></a>
-Gulp plugin to generate an imports file with a  table of contents 
+Gulp plugin to generate an imports file with a  table of contents
 
 This plugin was written to help with large scale website builds that use a CSS preprocessor and Gulp as a task runner.
 
@@ -10,7 +10,7 @@ The contents are generated from the first line of each individual SASS file.
 
 <sup>*</sup> The plugin requires a comment at the top of each SASS file formatted starting with // (double slash). The task will ignore files if they don't follow this format.
 
-### Install 
+### Install
 ```
 npm install gulp-sass-generate-contents
 ```
@@ -29,6 +29,12 @@ Default value: `true`
 
 Set to `false` to disable the contents table comment block in the output CSS
 
+#### options.excludeExtension
+Type: `Boolean`
+Default value: `false`
+
+Set to `true` to exclude file extensions from the generated file
+
 
 ### Example of SASS file to be imported
 
@@ -45,7 +51,7 @@ Set to `false` to disable the contents table comment block in the output CSS
 
 ```javascript
 
-// Settings 
+// Settings
 var gsgc = require('gulp-sass-generate-contents');
 var creds = {
 	"Author": 	"Andrew Brandwood",
@@ -72,12 +78,12 @@ gulp.task('gulp-sass-generate-contents', function () {
 
 ```
 ### Example of Output
-Based on Harry Roberts' @csswizardry ITCSS - 
+Based on Harry Roberts' @csswizardry ITCSS -
 [Link to Harry explaining the concept to creative block](http://www.creativebloq.com/web-design/manage-large-scale-web-projects-new-css-architecture-itcss-41514731)
 
 ```
 /*------------------------------------*\
-    
+
     #MAIN
     Site:   www.brandwood.com
     Author: Andrew Brandwood

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ function sassGenerateContents(destFilePath, creds, options){
 
 	var defaults = {
 		forceComments: true,
-		contentsTable: true
+		contentsTable: true,
+		excludeExtension: false
 	};
 	var opts = objectAssign(defaults, options);
 	var comments = '';
@@ -154,6 +155,11 @@ function sassGenerateContents(destFilePath, creds, options){
 	}
 
 	function generateImportString(filePath) {
+		if (opts.excludeExtension) {
+			var pathObject = path.parse(filePath);
+			filePath = path.join(pathObject.dir, pathObject.name);
+		}
+
 		var pathArray = path.normalize(filePath).split(path.sep);
 
 		return '@import "' + pathArray.join('/') + '";';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sass-generate-contents",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Andrew Brandwood",
     "email": "andrew@brandwood.com"

--- a/test/test.js
+++ b/test/test.js
@@ -107,4 +107,28 @@ describe('gulp-sass-generate-contents', function() {
             .pipe(assert.end(done));
     });
 
+    it('should not output file extensions', function (done) {
+        gulpTestRunner({
+            src: '/components/_test.scss',
+            dest: '/_no-extensions.scss',
+            settings: { excludeExtension: true },
+            assertion: function (fileContent) {
+                fileContent.should.not.match(/@import "((?:\/|\\)[\w\W]+).scss";/gi);
+            }
+        })
+            .pipe(assert.end(done));
+    });
+
+    it('should output file extensions', function (done) {
+        gulpTestRunner({
+            src: '/components/_test.scss',
+            dest: '/_has-extensions.scss',
+            settings: { excludeExtension: false },
+            assertion: function (fileContent) {
+                fileContent.should.match(/@import "((?:\/|\\)[\w\W]+).scss";/gi);
+            }
+        })
+            .pipe(assert.end(done));
+    });
+
 });


### PR DESCRIPTION
When importing things like css in to a sass file the import command needs to exclude the file
extension otherwise the import is preserved as is which is counter to what you want. E.g:

`@import '/some/path/to/file.css'` will be output as `@import '/some/path/to/file.css'` in the generated css.

While `@import '/some/path/to/file' will instead include the css contained within the file.